### PR TITLE
Default to sign URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 credentials.json
 pods.json
+serverConfig.json
+node_modules
+vendor

--- a/serverConfig.json.example
+++ b/serverConfig.json.example
@@ -1,7 +1,7 @@
 {
   "hostname": "localhost",
   "port": 4000,
-  "mintUrl": "http://localhost:4000/api/mintPOD",
+  "mintUrl": "http://localhost:4000/api/sign",
   "zupassUrl": "http://localhost:3000",
   "defaultPrivateKey": "AAECAwQFBgcICQABAgMEBQYHCAkAAQIDBAUGBwgJAAA"
 }


### PR DESCRIPTION
The /api/sign URL seems to already return a serialized PODPCD.  If Zupass changes to expect this, I think this change will make it just work, at least for newly generated URLs.

I can't seem to test this locally because Deno setup doesn't work.  here's what I see after installing Deno and trying to make:

```
[~/dev/pod-issuer]% make
Caching dependencies...
Warning The following packages contained npm lifecycle scripts (preinstall/install/postinstall) that were not executed:
┠─ npm:blake-hash@2.0.0
┃
┠─ This may cause the packages to not work correctly.
┖─ To run lifecycle scripts, use the `--allow-scripts` flag with `deno install`:
   deno install --allow-scripts=npm:blake-hash@2.0.0
Patching dependencies...
sed: 1: "node_modules/.deno/@pcd ...": extra characters at the end of n command
make: *** [patch] Error 1

```